### PR TITLE
Fix: Update default models to latest stable versions

### DIFF
--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -28,9 +28,9 @@ export async function initGeminiClient(): Promise<void> {
 
     // Set up models
     proModelName =
-      process.env.GEMINI_PRO_MODEL || 'gemini-2.5-pro-exp-03-25'
+      process.env.GEMINI_PRO_MODEL || 'gemini-2.5-pro'
     flashModelName =
-      process.env.GEMINI_FLASH_MODEL || 'gemini-2.0-flash-001'
+      process.env.GEMINI_FLASH_MODEL || 'gemini-2.5-flash'
 
     // Test connection with timeout and retry
     let connected = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ if (!process.env.GEMINI_API_KEY) {
 
 // Get model name from environment or use default
 // Use a safeguard to ensure we always have a valid model name
-const defaultModel = 'gemini-2.5-pro-preview-03-25'
+const defaultModel = 'gemini-2.5-pro'
 const geminiModel = process.env.GEMINI_MODEL || defaultModel
 
 // Log model configuration for debugging


### PR DESCRIPTION
## Summary
Fixes #4 - Updates default Gemini models from non-existent experimental versions to the latest stable versions.

## Changes
- Updated default Pro model from `gemini-2.5-pro-exp-03-25` to `gemini-2.5-pro`
- Updated default Flash model from `gemini-2.0-flash-001` to `gemini-2.5-flash`  
- Updated default model in index.ts from `gemini-2.5-pro-preview-03-25` to `gemini-2.5-pro`

## Testing
- Server now connects successfully with just `GEMINI_API_KEY` environment variable
- No need to specify model configurations unless custom models are desired
- Tested connection with the updated defaults

## Benefits
- Fixes immediate connection failures for new users
- Uses officially documented stable model names from https://ai.google.dev/gemini-api/docs/models
- More maintainable as these model aliases are updated by Google to point to latest stable versions