### PR TITLE
fix: Deep Research needs Interactions steps schema (genai 2.x) + route MCP logs to stderr

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@rlabs-inc/gemini-mcp",
       "dependencies": {
-        "@google/genai": "^1.34.0",
+        "@google/genai": "^2.9.0",
         "@modelcontextprotocol/sdk": "1.22.0",
         "zod": "3.24.3",
         "zod-to-json-schema": "3.24.5",
@@ -97,7 +97,7 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
-    "@google/genai": ["@google/genai@1.34.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0" } }, ""],
+    "@google/genai": ["@google/genai@2.9.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -114,6 +114,24 @@
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.22.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-VUpl106XVTCpDmTBil2ehgJZjhyLY2QZikzF8NvTXtLRF1CvO5iEE2UNZdVIUer35vFOwMKYeUGbjJtvPWan3g=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, ""],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.57.1", "", { "os": "android", "cpu": "arm" }, "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg=="],
 
@@ -178,6 +196,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@20.19.31", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.54.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.54.0", "@typescript-eslint/type-utils": "8.54.0", "@typescript-eslint/utils": "8.54.0", "@typescript-eslint/visitor-keys": "8.54.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.54.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ=="],
 
@@ -457,6 +477,8 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, ""],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "lru-cache": ["lru-cache@10.4.3", "", {}, ""],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -503,6 +525,8 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, ""],
 
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, ""],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -531,6 +555,8 @@
 
     "prettier": ["prettier@3.5.3", "", { "bin": "bin/prettier.cjs" }, ""],
 
+    "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, ""],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -544,6 +570,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": "dist/esm/bin.mjs" }, ""],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@google/genai": "^1.34.0",
+    "@google/genai": "^2.9.0",
     "@modelcontextprotocol/sdk": "1.22.0",
     "zod": "3.24.3",
     "zod-to-json-schema": "3.24.5"

--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -587,15 +587,19 @@ export interface DeepResearchResult {
   savedPath?: string // Path to full response JSON file
 }
 
-// Deep Research agent model
-const DEEP_RESEARCH_AGENT = 'deep-research-pro-preview-12-2025'
+// Deep Research agent model. The 12-2025 preview agent is deprecated; the current
+// agents are deep-research-preview-04-2026 (speed) and deep-research-max-preview-04-2026
+// (comprehensiveness). Overridable via env so a future agent rev needs no code change.
+const DEEP_RESEARCH_AGENT =
+  process.env.GEMINI_DEEP_RESEARCH_AGENT || 'deep-research-preview-04-2026'
 
 /**
  * Start a deep research task
  */
 export async function startDeepResearch(prompt: string): Promise<DeepResearchResult> {
   try {
-    // The Interactions API is properly typed in @google/genai v1.34.0+
+    // The Interactions API "steps" schema requires @google/genai >= 2.0.0 (the legacy
+    // "outputs" schema was removed by Google on 2026-06-08).
     const interaction = await genAI.interactions.create({
       input: prompt,
       agent: DEEP_RESEARCH_AGENT,
@@ -634,22 +638,29 @@ export async function checkDeepResearch(researchId: string): Promise<DeepResearc
         status: interaction.status,
         created: interaction.created,
         agent: interaction.agent,
-        model: interaction.model,
-        outputs: interaction.outputs,
+        steps: interaction.steps,
         rawInteraction: interaction,
       }
       fs.writeFileSync(outputPath, JSON.stringify(fullResponse, null, 2))
       logger.info(`Full deep research response saved to: ${outputPath}`)
 
-      // Extract text for the summary (but full data is saved)
-      const textOutputs = (interaction.outputs || [])
-        .filter((output) => 'type' in output && output.type === 'text')
-        .map((output) => ({ text: (output as { text?: string }).text }))
+      // Extract the final report text. The June-2026 Interactions API ("steps" schema,
+      // @google/genai >= 2.0.0) exposes the convenience accessor output_text; fall back
+      // to any text emitted across the steps array.
+      const reportText =
+        interaction.output_text ||
+        (interaction.steps || [])
+          .map((step) => {
+            const s = step as { text?: string; content?: { text?: string } }
+            return s.text || s.content?.text
+          })
+          .filter((text): text is string => !!text)
+          .join('\n\n')
 
       return {
         id: researchId,
         status: 'completed',
-        outputs: textOutputs,
+        outputs: reportText ? [{ text: reportText }] : [],
         savedPath: outputPath,
       }
     } else if (status === 'failed' || status === 'cancelled') {
@@ -681,15 +692,20 @@ export async function followUpResearch(researchId: string, question: string): Pr
       previous_interaction_id: researchId,
     })
 
-    // Extract text from TextContent outputs
-    const outputs = interaction.outputs || []
-    const textOutputs = outputs
-      .filter((output) => 'type' in output && output.type === 'text')
-      .map((output) => (output as { text?: string }).text)
-      .filter((text): text is string => !!text)
+    // The new Interactions API exposes the convenience accessor output_text.
+    if (interaction.output_text) {
+      return interaction.output_text
+    }
 
-    if (textOutputs.length > 0) {
-      return textOutputs[textOutputs.length - 1]
+    // Fallback: pull any text emitted across the steps array.
+    const stepTexts = (interaction.steps || [])
+      .map((step) => {
+        const s = step as { text?: string; content?: { text?: string } }
+        return s.text || s.content?.text
+      })
+      .filter((text): text is string => !!text)
+    if (stepTexts.length > 0) {
+      return stepTexts[stepTexts.length - 1]
     }
 
     return 'No text response received'

--- a/src/tools/analyze.ts
+++ b/src/tools/analyze.ts
@@ -42,7 +42,7 @@ export function registerAnalyzeTool(server: McpServer): void {
         .describe('What aspect to focus the analysis on'),
     },
     async ({ code, filePath, filePaths, language, focus }) => {
-      console.log(`Analyzing code with focus on ${focus}`)
+      console.error(`Analyzing code with focus on ${focus}`)
 
       try {
         // Normalize file paths
@@ -92,7 +92,7 @@ export function registerAnalyzeTool(server: McpServer): void {
         .describe('Type of analysis to perform'),
     },
     async ({ text, type }) => {
-      console.log(`Analyzing text with focus on ${type}`)
+      console.error(`Analyzing text with focus on ${type}`)
 
       try {
         const prompt = `

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -28,7 +28,7 @@ export function registerQueryTool(server: McpServer): void {
         ),
     },
     async ({ prompt, model, thinkingLevel }) => {
-      console.log(
+      console.error(
         `Querying Gemini ${model} model (thinking: ${thinkingLevel || 'default'}) with prompt: ${prompt.substring(0, 100)}...`
       )
 

--- a/src/tools/summarize.ts
+++ b/src/tools/summarize.ts
@@ -20,7 +20,7 @@ export function registerSummarizeTool(server: McpServer): void {
       format: z.enum(['paragraph', 'bullet-points', 'outline']).default('paragraph').describe('The output format'),
     },
     async ({ content, length, format }) => {
-      console.log(`Summarizing content (${length}, ${format})`)
+      console.error(`Summarizing content (${length}, ${format})`)
 
       try {
         // Configure length parameters

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -64,36 +64,36 @@ export const logger: Logger = {
   info: (message: string, ...args: unknown[]) => {
     // Info messages are logged in normal and verbose modes
     if (shouldLogInfo()) {
-      console.info(`INFO: ${message}`, ...args)
+      console.error(`INFO: ${message}`, ...args)
     }
   },
 
   debug: (message: string, ...args: unknown[]) => {
     // Debug messages are only logged in verbose mode
     if (shouldLogDebug()) {
-      console.debug(`DEBUG: ${message}`, ...args)
+      console.error(`DEBUG: ${message}`, ...args)
     }
   },
 
   prompt: (prompt: string) => {
     // Prompts are only fully logged in verbose mode
     if (shouldLogFullMessages()) {
-      console.info(`\n===== PROMPT =====\n${prompt}\n==================\n`)
+      console.error(`\n===== PROMPT =====\n${prompt}\n==================\n`)
     } else if (shouldLogInfo()) {
       // In normal mode, just log a summary
       const summary = prompt.length > 100 ? `${prompt.substring(0, 100)}...` : prompt
-      console.info(`PROMPT: ${summary}`)
+      console.error(`PROMPT: ${summary}`)
     }
   },
 
   response: (response: string) => {
     // Responses are only fully logged in verbose mode
     if (shouldLogFullMessages()) {
-      console.info(`\n===== RESPONSE =====\n${response}\n====================\n`)
+      console.error(`\n===== RESPONSE =====\n${response}\n====================\n`)
     } else if (shouldLogInfo()) {
       // In normal mode, just log a summary
       const summary = response.length > 100 ? `${response.substring(0, 100)}...` : response
-      console.info(`RESPONSE: ${summary}`)
+      console.error(`RESPONSE: ${summary}`)
     }
   },
 }


### PR DESCRIPTION
Fixes two independent, currently-blocking bugs in the MCP server. They touch disjoint files and can be split into two PRs if you prefer.

## 1. Deep Research is broken against Google's current Interactions API

Every `gemini-deep-research` call fails:

```
400 The legacy Interactions API schema is no longer supported. Please upgrade your
client SDK to Python >= 2.0.0 or JavaScript/TypeScript >= 2.0.0 to adopt the new
'steps' schema.
(https://ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026)
```

Google removed the legacy `outputs` response schema on 2026-06-08; the Interactions API now returns a `steps` array that requires `@google/genai >= 2.0.0`. The package pins `^1.34.0`, so deep research 400s for everyone.

**Fix**
- Bump `@google/genai` `^1.34.0` → `^2.9.0`.
- Update the default Deep Research agent from the deprecated `deep-research-pro-preview-12-2025` to `deep-research-preview-04-2026` (overridable via a new `GEMINI_DEEP_RESEARCH_AGENT` env var).
- Read the result via the `interaction.output_text` accessor (with a `steps[]` fallback) instead of the removed `interaction.outputs`, in `checkDeepResearch` and `followUpResearch`.

## 2. MCP server won't connect — logs corrupt the stdio protocol

On startup the server writes ~684 bytes of `INFO:` logs to **stdout**. MCP stdio reserves stdout for JSON-RPC, so those bytes corrupt the handshake and the server's tools never register in the client. Root cause: the logger uses `console.info`/`console.debug` (Node routes both to stdout), and the `query`/`summarize`/`analyze` tools use `console.log`.

**Fix** — route logger info/debug and those tool breadcrumbs to **stderr** (`console.error`). `--help` output (CLI-only, never in the MCP path) is left on stdout.

## Testing

- `bun run build` is clean — all tool groups compile against `@google/genai` 2.x.
- Live, end-to-end: a `gemini-deep-research` job runs to completion and returns a cited report; `gemini-query`, `gemini-generate-image` (`gemini-3-pro-image`), and `count-tokens` all verified on 2.x.
- stdout byte-count on startup: **684 → 0** after the logging fix; the server then connects and all tools register.
