### PR TITLE
add native HTTP/HTTPS proxy support for Gemini API connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides essential information for Claude when working with this G
 
 This project is an MCP (Model Context Protocol) server that connects Claude to Google's Gemini 3 AI models. It enables bidirectional collaboration between Claude and Gemini, allowing them to work together by sharing capabilities and agent tools.
 
-**Version:** 0.8.0
+**Version:** 0.8.1
 **Package:** @rlabs-inc/gemini-mcp
 **MCP Registry:** io.github.rlabs-inc/gemini-mcp
 
@@ -119,6 +119,8 @@ This project is an MCP (Model Context Protocol) server that connects Claude to G
 | `QUIET` | No | `false` | Minimize logging |
 | `GEMINI_ENABLED_TOOLS` | No | - | Comma-separated list of tool groups to load |
 | `GEMINI_TOOL_PRESET` | No | - | Preset profile: minimal, text, image, research, media, full |
+| `HTTP_PROXY` | No | - | HTTP proxy URL (e.g. `http://127.0.0.1:7890`) for routing traffic through a proxy |
+| `HTTPS_PROXY` | No | - | HTTPS proxy URL; used as fallback when `HTTP_PROXY` is not set |
 
 ## Command Line Options
 
@@ -129,7 +131,14 @@ This project is an MCP (Model Context Protocol) server that connects Claude to G
 ## Installation
 
 ```bash
+# Basic install
 claude mcp add gemini -s user -- env GEMINI_API_KEY=YOUR_KEY npx -y @rlabs-inc/gemini-mcp
+
+# With HTTP proxy (for developers behind firewalls)
+claude mcp add gemini -s user -- \
+  env GEMINI_API_KEY=YOUR_KEY \
+  HTTP_PROXY=http://127.0.0.1:7890 \
+  npx -y @rlabs-inc/gemini-mcp
 ```
 
 ## Development Commands
@@ -148,6 +157,7 @@ bun run lint       # Lint code with ESLint
 
 - `@google/genai`: ^1.34.0 - Google Generative AI SDK
 - `@modelcontextprotocol/sdk`: 1.22.0 - MCP SDK (pinned; 1.23.0+ causes TypeScript OOM)
+- `undici`: ^7.0.0 - HTTP client used to inject global proxy support for Node.js fetch()
 - `zod`: 3.24.3 - Schema validation (pinned for compatibility with MCP SDK)
 - `zod-to-json-schema`: 3.24.5 - Zod to JSON Schema conversion (pinned; 3.25+ requires zod/v3 export)
 
@@ -159,6 +169,7 @@ bun run lint       # Lint code with ESLint
 - Generated files are saved to `GEMINI_OUTPUT_DIR`
 - Thinking levels control reasoning depth in Gemini 3
 - Image editing uses chat sessions with automatic thought signature handling
+- **HTTP Proxy**: `src/index.ts` injects a global `undici` ProxyAgent before any network calls when `HTTP_PROXY` / `HTTPS_PROXY` is set. This is needed because Node.js's built-in `fetch()` does not natively respect these env vars (unlike Bun, which does).
 
 ## Gemini 3 Specific Features
 
@@ -184,6 +195,11 @@ bun run lint       # Lint code with ESLint
 - **Image Analysis Tool**: New `gemini-analyze-image` with object detection and bounding boxes (community contribution by @acreeger)
 - **Thinking Level Support**: Added thinkingLevel parameter to image analysis for complex visual reasoning
 - **Dual Coordinate Output**: Returns both normalized (box_2d) and pixel (bbox_pixels) coordinates
+
+## Key Changes (unreleased)
+
+- **HTTP Proxy Support**: `src/index.ts` now natively reads `HTTP_PROXY` / `HTTPS_PROXY` env vars and injects a global `undici` ProxyAgent before any network request. No external wrapper script needed.
+- **New dependency**: `undici` added for proxy agent injection.
 
 ### Previous Versions
 - v0.7.x: Published to MCP Registry, CLI renamed to gcli

--- a/README.md
+++ b/README.md
@@ -430,6 +430,21 @@ bun install -g @rlabs-inc/gemini-mcp
     }
   }
 }
+
+If you must use a proxy to establish a connection to gemini , you can use below json
+```json
+{
+  "gemini": {
+    "command": "npx",
+    "args": ["-y", "@rlabs-inc/gemini-mcp"],
+    "env": {
+      "GEMINI_API_KEY": "your-api-key",
+      "GEMINI_OUTPUT_DIR": "/path/to/save/files",
+	"HTTP_PROXY": "http://127.0.0.1:xxxx", // xxxx is your proxy port
+        "HTTPS_PROXY": "http://127.0.0.1:xxxx"
+    }
+  }
+}
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ bun install -g @rlabs-inc/gemini-mcp
   }
 }
 
-If you must use a proxy to establish a connection to gemini , you can use below json
+If you must use a proxy to establish a connection to gemini, you can use below json (replace `xxxx` with your actual proxy port):
 {
   "gemini": {
     "command": "npx",
@@ -439,8 +439,8 @@ If you must use a proxy to establish a connection to gemini , you can use below 
     "env": {
       "GEMINI_API_KEY": "your-api-key",
       "GEMINI_OUTPUT_DIR": "/path/to/save/files",
-	"HTTP_PROXY": "http://127.0.0.1:your proxy port", 
-        "HTTPS_PROXY": "http://127.0.0.1:your proxy port"
+	"HTTP_PROXY": "http://127.0.0.1:xxxx", 
+        "HTTPS_PROXY": "http://127.0.0.1:xxxx"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -430,8 +430,11 @@ bun install -g @rlabs-inc/gemini-mcp
     }
   }
 }
+```
 
-If you must use a proxy to establish a connection to gemini, you can use below json (replace `xxxx` with your actual proxy port):
+If you must use a proxy to establish a connection to gemini, replace `xxxx` with your actual proxy port:
+
+```json
 {
   "gemini": {
     "command": "npx",
@@ -439,8 +442,8 @@ If you must use a proxy to establish a connection to gemini, you can use below j
     "env": {
       "GEMINI_API_KEY": "your-api-key",
       "GEMINI_OUTPUT_DIR": "/path/to/save/files",
-	"HTTP_PROXY": "http://127.0.0.1:xxxx", 
-        "HTTPS_PROXY": "http://127.0.0.1:xxxx"
+      "HTTP_PROXY": "http://127.0.0.1:xxxx",
+      "HTTPS_PROXY": "http://127.0.0.1:xxxx"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -432,7 +432,6 @@ bun install -g @rlabs-inc/gemini-mcp
 }
 
 If you must use a proxy to establish a connection to gemini , you can use below json
-```json
 {
   "gemini": {
     "command": "npx",
@@ -440,8 +439,8 @@ If you must use a proxy to establish a connection to gemini , you can use below 
     "env": {
       "GEMINI_API_KEY": "your-api-key",
       "GEMINI_OUTPUT_DIR": "/path/to/save/files",
-	"HTTP_PROXY": "http://127.0.0.1:xxxx", // xxxx is your proxy port
-        "HTTPS_PROXY": "http://127.0.0.1:xxxx"
+	"HTTP_PROXY": "http://127.0.0.1:your proxy port", 
+        "HTTPS_PROXY": "http://127.0.0.1:your proxy port"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google/genai": "^1.34.0",
         "@modelcontextprotocol/sdk": "1.22.0",
+        "undici": "^7.0.0",
         "zod": "3.24.3",
         "zod-to-json-schema": "3.24.5"
       },
@@ -20,7 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/node": "^20.19.31",
         "eslint": "^9.0.0",
         "husky": "^9.0.0",
@@ -3878,6 +3879,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@google/genai": "^1.34.0",
     "@modelcontextprotocol/sdk": "1.22.0",
+    "undici": "^7.0.0",
     "zod": "3.24.3",
     "zod-to-json-schema": "3.24.5"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
 
 import { runCli } from './cli/index.js'
 import { startMcpServer } from './server.js'
+import { logger } from './utils/logger.js'
 
 // --- Global HTTP proxy injection for Node.js native fetch ---
 // Node.js's built-in fetch (powered by undici) does NOT automatically read
@@ -32,9 +33,9 @@ import { createRequire } from 'node:module'
     // Node 18+ uses undici internally; the symbol is the same regardless of whether
     // undici is bundled by Node or installed as a standalone package.
     ;(globalThis as Record<symbol, unknown>)[Symbol.for('undici.globalDispatcher.1')] = dispatcher
-    console.error(`[Proxy] Detected HTTP_PROXY, global proxy agent injected.`)
+    logger.info(`[Proxy] Detected HTTP_PROXY, global proxy agent injected.`)
   } catch (err: unknown) {
-    console.error(
+    logger.error(
       `[Proxy] Failed to inject proxy agent: ${err instanceof Error ? err.message : String(err)}`
     )
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,33 @@
 import { runCli } from './cli/index.js'
 import { startMcpServer } from './server.js'
 
+// --- Global HTTP proxy injection for Node.js native fetch ---
+// Node.js's built-in fetch (powered by undici) does NOT automatically read
+// HTTP_PROXY / HTTPS_PROXY. We manually inject a ProxyAgent as the global
+// undici dispatcher so all downstream network calls (including @google/genai)
+// go through the proxy, which is essential for developers behind firewalls.
+import { createRequire } from 'node:module'
+
+;(function setupGlobalProxy(): void {
+  const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY
+  if (!proxyUrl) return
+
+  try {
+    const req = createRequire(import.meta.url)
+    const { ProxyAgent } = req('undici') as { ProxyAgent: new (uri: string) => unknown }
+    const dispatcher = new ProxyAgent(proxyUrl)
+    // This symbol is the stable hook undici exposes to replace its global dispatcher.
+    // Node 18+ uses undici internally; the symbol is the same regardless of whether
+    // undici is bundled by Node or installed as a standalone package.
+    ;(globalThis as Record<symbol, unknown>)[Symbol.for('undici.globalDispatcher.1')] = dispatcher
+    console.error(`[Proxy] Detected HTTP_PROXY, global proxy agent injected.`)
+  } catch (err: unknown) {
+    console.error(
+      `[Proxy] Failed to inject proxy agent: ${err instanceof Error ? err.message : String(err)}`
+    )
+  }
+})()
+
 // Get command line arguments
 const args = process.argv.slice(2)
 


### PR DESCRIPTION
### Description
This PR adds native HTTP/HTTPS proxy support by injecting an undici `ProxyAgent` globally when `process.env.HTTP_PROXY` or `process.env.HTTPS_PROXY` is present. 

### Why is this needed?
Currently, Node.js native `fetch()` ignores environment proxy variables by default. Developers behind firewalls (e.g., in China) encounter consistent connection timeouts when calling the Gemini API. This change allows the MCP server to respect system proxy settings seamlessly.

### Changes
- Injected global dispatcher proxy in the entry point.
- Replaced `bun` environment scripts in `package.json` with native standard node/npm commands to ensure cross-platform compatibility (especially for Windows environments where `bun` or `chmod` might be missing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP proxy support for network connections, configurable via `HTTP_PROXY` and `HTTPS_PROXY`.

* **Documentation**
  * Updated setup and configuration guidance to include “with HTTP proxy” installation steps and example proxy configuration for Gemini.  
  * Refreshed project documentation to reflect the new proxy capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->